### PR TITLE
UPSTREAM: <carry>: match upstream binary location in image

### DIFF
--- a/openshift/Dockerfile
+++ b/openshift/Dockerfile
@@ -5,7 +5,7 @@ RUN make go-build-local
 
 FROM registry.ci.openshift.org/ocp/4.14:base
 
-COPY --from=builder /build/bin/manager /usr/bin/catalogd-controller
+COPY --from=builder /build/bin/manager /manager
 
 LABEL io.k8s.display-name="OpenShift Operator Lifecycle Manager Catalog Controller" \
       io.k8s.description="This is a component of OpenShift Container Platform that provides operator catalog support."


### PR DESCRIPTION
Upstream's Dockerfile puts the binary in /manager and the corresponding deployment yaml expects /manager. This change matches the upstream location so we don't have to patch the deployment yaml.