### PR TITLE
UPSTREAM: <carry>: add USER to OpenShift image

### DIFF
--- a/openshift/Dockerfile
+++ b/openshift/Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 RUN make go-build-local
 
 FROM registry.ci.openshift.org/ocp/4.14:base
-
+USER 1001
 COPY --from=builder /build/bin/manager /manager
 
 LABEL io.k8s.display-name="OpenShift Operator Lifecycle Manager Catalog Controller" \


### PR DESCRIPTION
Add the USER directive to the OpenShift Dockerfile so the image does not run as root by default. This allows the image to run in OpenShift when the container is configured to run as non-root.