### PR TITLE
OCPBUGS-19117: UPSTREAM: <carry>: Updating ose-olm-catalogd images to be consistent with ART

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
-  namespace: openshift
   name: release
-  tag: rhel-8-release-golang-1.20-openshift-4.14
+  namespace: openshift
+  tag: rhel-8-release-golang-1.20-openshift-4.15

--- a/openshift/Dockerfile
+++ b/openshift/Dockerfile
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS builder
 WORKDIR /build
 COPY . .
 RUN make go-build-local
 
-FROM registry.ci.openshift.org/ocp/4.14:base
+FROM registry.ci.openshift.org/ocp/4.15:base
 USER 1001
 COPY --from=builder /build/bin/manager /manager
 COPY openshift/manifests /openshift/manifests


### PR DESCRIPTION
Re-do of https://github.com/openshift/operator-framework-catalogd/pull/27 in a manner which will satisfy commitchecker. 
Future auto-generated PRs should be compliant: https://github.com/openshift-eng/ocp-build-data/pull/3531/files