### PR TITLE
OCPBUGS-41961: Fix webhook manifest generation

### DIFF
--- a/DOWNSTREAM_OWNERS_ALIASES
+++ b/DOWNSTREAM_OWNERS_ALIASES
@@ -9,6 +9,7 @@ aliases:
    - stevekuznetsov
    - m1kola
    - everettraven
+   - tmshort
 
    # Contributors who can review/lgtm any PRs in the repo
    catalogd-reviewers:

--- a/openshift/generate-manifests.sh
+++ b/openshift/generate-manifests.sh
@@ -29,7 +29,7 @@ IMAGE_MAPPINGS[manager]='${CATALOGD_IMAGE}'
 #  - --flagname=two
 declare -A FLAG_MAPPINGS
 # shellcheck disable=SC2016
-FLAG_MAPPINGS[external-address]='catalogd-catalogserver.openshift-catalogd.svc'
+FLAG_MAPPINGS[external-address]="catalogd-service.${NAMESPACE}.svc"
 
 ##################################################
 # You shouldn't need to change anything below here
@@ -47,11 +47,12 @@ TMP_ROOT="$(mktemp -p . -d 2>/dev/null || mktemp -d ./tmpdir.XXXXXXX)"
 trap 'rm -rf $TMP_ROOT' EXIT
 
 # Copy all kustomize files into a temp dir
-TMP_CONFIG="${TMP_ROOT}/config"
-cp -a "${REPO_ROOT}/config" "$TMP_CONFIG"
+cp -a "${REPO_ROOT}/config" "${TMP_ROOT}/config"
+mkdir -p "${TMP_ROOT}/openshift"
+cp -a "${REPO_ROOT}/openshift/kustomize" "${TMP_ROOT}/openshift/kustomize"
 
-# Override namespace to openshift-catalogd
-$YQ -i ".namespace = \"${NAMESPACE}\"" "${TMP_CONFIG}/base/default/kustomization.yaml"
+# Override OPENSHIFT-NAMESPACE to ${NAMESPACE}
+find "${TMP_ROOT}" -name "*.yaml" -exec sed -i "s/OPENSHIFT-NAMESPACE/${NAMESPACE}/g" {} \;
 
 # Create a temp dir for manifests
 TMP_MANIFEST_DIR="${TMP_ROOT}/manifests"
@@ -59,7 +60,7 @@ mkdir -p "$TMP_MANIFEST_DIR"
 
 # Run kustomize, which emits a single yaml file
 TMP_KUSTOMIZE_OUTPUT="${TMP_MANIFEST_DIR}/temp.yaml"
-$KUSTOMIZE build "${REPO_ROOT}"/openshift/kustomize/overlays/openshift -o "$TMP_KUSTOMIZE_OUTPUT"
+$KUSTOMIZE build "${TMP_ROOT}/openshift/kustomize/overlays/openshift" -o "$TMP_KUSTOMIZE_OUTPUT"
 
 for container_name in "${!IMAGE_MAPPINGS[@]}"; do
   placeholder="${IMAGE_MAPPINGS[$container_name]}"

--- a/openshift/kustomize/overlays/openshift/kustomization.yaml
+++ b/openshift/kustomize/overlays/openshift/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: openshift-catalogd
+namespace: OPENSHIFT-NAMESPACE
 
 namePrefix: catalogd-
 
@@ -11,13 +11,13 @@ resources:
 patches:
 - target:
     kind: Service
-    name: catalogserver
+    name: service
   path: patches/manager_service.yaml
+- target:
+    kind: MutatingWebhookConfiguration
+    name: mutating-webhook-configuration
+  path: patches/mutating_webhook_config.yaml
 - target:
     kind: Deployment
     name: controller-manager
   path: patches/manager_deployment_certs.yaml
-- target:
-    kind: Service
-    name: catalogserver
-  path: patches/catalogserver_service_port.yaml

--- a/openshift/kustomize/overlays/openshift/patches/catalogserver_service_port.yaml
+++ b/openshift/kustomize/overlays/openshift/patches/catalogserver_service_port.yaml
@@ -1,6 +1,0 @@
-- op: replace
-  path: /spec/ports/0/port
-  value: 443
-- op: replace
-  path: /spec/ports/0/name
-  value: https

--- a/openshift/kustomize/overlays/openshift/patches/manager_service.yaml
+++ b/openshift/kustomize/overlays/openshift/patches/manager_service.yaml
@@ -1,5 +1,10 @@
-kind: Service
-metadata:
-  name: catalogserver
-  annotations:
+- op: add
+  path: /metadata/annotations
+  value:
     service.beta.openshift.io/serving-cert-secret-name: catalogserver-cert
+- op: replace
+  path: /spec/ports/0/port
+  value: 443
+- op: replace
+  path: /spec/ports/0/name
+  value: https

--- a/openshift/kustomize/overlays/openshift/patches/mutating_webhook_config.yaml
+++ b/openshift/kustomize/overlays/openshift/patches/mutating_webhook_config.yaml
@@ -1,0 +1,7 @@
+- op: add
+  path: /metadata/annotations
+  value:
+    service.beta.openshift.io/inject-cabundle: "true"
+- op: replace
+  path: /webhooks/0/clientConfig/service/namespace
+  value: OPENSHIFT-NAMESPACE

--- a/openshift/manifests/10-service-openshift-catalogd-catalogd-service.yml
+++ b/openshift/manifests/10-service-openshift-catalogd-catalogd-service.yml
@@ -2,6 +2,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: catalogserver-cert
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -9,8 +11,8 @@ metadata:
   namespace: openshift-catalogd
 spec:
   ports:
-    - name: http
-      port: 80
+    - name: https
+      port: 443
       protocol: TCP
       targetPort: 8443
     - name: webhook

--- a/openshift/manifests/11-deployment-openshift-catalogd-catalogd-controller-manager.yml
+++ b/openshift/manifests/11-deployment-openshift-catalogd-catalogd-controller-manager.yml
@@ -65,7 +65,7 @@ spec:
         - args:
             - --leader-elect
             - --metrics-bind-address=127.0.0.1:8080
-            - --external-address=catalogd-catalogserver.openshift-catalogd.svc
+            - --external-address=catalogd-service.openshift-catalogd.svc
             - --tls-cert=/var/certs/tls.crt
             - --tls-key=/var/certs/tls.key
           command:

--- a/openshift/manifests/12-mutatingwebhookconfiguration-catalogd-mutating-webhook-configuration.yml
+++ b/openshift/manifests/12-mutatingwebhookconfiguration-catalogd-mutating-webhook-configuration.yml
@@ -2,6 +2,8 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
   name: catalogd-mutating-webhook-configuration
 webhooks:
   - admissionReviewVersions:
@@ -9,7 +11,7 @@ webhooks:
     clientConfig:
       service:
         name: catalogd-service
-        namespace: olmv1-system
+        namespace: openshift-catalogd
         path: /mutate-olm-operatorframework-io-v1alpha1-clustercatalog
         port: 9443
     failurePolicy: Fail


### PR DESCRIPTION
Update the webhook's namespace and add openshift cert annotations
Update the generate script to properly use the TMP_ROOT directory
Consolidate the namespace to one variable