### PR TITLE
OPRUN-3552: UPSTREAM: <carry>: manifests: add hostPath mount for /etc/containers

### DIFF
--- a/openshift/generate-manifests.sh
+++ b/openshift/generate-manifests.sh
@@ -66,7 +66,7 @@ for container_name in "${!IMAGE_MAPPINGS[@]}"; do
   placeholder="${IMAGE_MAPPINGS[$container_name]}"
   $YQ -i "(select(.kind == \"Deployment\")|.spec.template.spec.containers[]|select(.name==\"$container_name\")|.image) = \"$placeholder\"" "$TMP_KUSTOMIZE_OUTPUT"
   $YQ -i 'select(.kind == "Deployment").spec.template.metadata.annotations += {"target.workload.openshift.io/management": "{\"effect\": \"PreferredDuringScheduling\"}"}' "$TMP_KUSTOMIZE_OUTPUT"
-  $YQ -i 'select(.kind == "Deployment").spec.template.metadata.annotations += {"openshift.io/required-scc": "restricted-v2"}' "$TMP_KUSTOMIZE_OUTPUT"
+  $YQ -i 'select(.kind == "Deployment").spec.template.metadata.annotations += {"openshift.io/required-scc": "privileged"}' "$TMP_KUSTOMIZE_OUTPUT"
   $YQ -i 'select(.kind == "Deployment").spec.template.spec += {"priorityClassName": "system-cluster-critical"}' "$TMP_KUSTOMIZE_OUTPUT"
   $YQ -i 'select(.kind == "Namespace").metadata.annotations += {"workload.openshift.io/allowed": "management"}' "$TMP_KUSTOMIZE_OUTPUT"
 done

--- a/openshift/kustomize/overlays/openshift/kustomization.yaml
+++ b/openshift/kustomize/overlays/openshift/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - ../../../../config/base/manager
 
 patches:
+- path: patches/manager_namespace_privileged.yaml
 - target:
     kind: Service
     name: service
@@ -18,6 +19,14 @@ patches:
     name: mutating-webhook-configuration
   path: patches/mutating_webhook_config.yaml
 - target:
+    kind: ClusterRole
+    name: manager-role
+  path: patches/manager_role.yaml
+- target:
     kind: Deployment
     name: controller-manager
   path: patches/manager_deployment_certs.yaml
+- target:
+    kind: Deployment
+    name: controller-manager
+  path: patches/manager_deployment_mount_etc_containers.yaml

--- a/openshift/kustomize/overlays/openshift/patches/manager_deployment_mount_etc_containers.yaml
+++ b/openshift/kustomize/overlays/openshift/patches/manager_deployment_mount_etc_containers.yaml
@@ -1,0 +1,6 @@
+- op: add
+  path: /spec/template/spec/volumes/-
+  value: {"name":"etc-containers", "hostPath":{"path":"/etc/containers", "type": "Directory"}}
+- op: add
+  path: /spec/template/spec/containers/1/volumeMounts/-
+  value: {"name":"etc-containers", "readOnly": true, "mountPath":"/etc/containers"}

--- a/openshift/kustomize/overlays/openshift/patches/manager_namespace_privileged.yaml
+++ b/openshift/kustomize/overlays/openshift/patches/manager_namespace_privileged.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: system
+  labels:
+    pod-security.kubernetes.io/enforce: privileged

--- a/openshift/kustomize/overlays/openshift/patches/manager_role.yaml
+++ b/openshift/kustomize/overlays/openshift/patches/manager_role.yaml
@@ -1,0 +1,7 @@
+- op: add
+  path: /rules/-
+  value:
+    apiGroups: [security.openshift.io]
+    resources: [securitycontextconstraints]
+    resourceNames: [privileged]
+    verbs: [use]

--- a/openshift/manifests/00-namespace-openshift-catalogd.yml
+++ b/openshift/manifests/00-namespace-openshift-catalogd.yml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   labels:
     app.kubernetes.io/part-of: olm
-    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/enforce-version: latest
   name: openshift-catalogd
   annotations:

--- a/openshift/manifests/04-clusterrole-catalogd-manager-role.yml
+++ b/openshift/manifests/04-clusterrole-catalogd-manager-role.yml
@@ -30,3 +30,11 @@ rules:
       - get
       - patch
       - update
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - privileged
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use

--- a/openshift/manifests/11-deployment-openshift-catalogd-catalogd-controller-manager.yml
+++ b/openshift/manifests/11-deployment-openshift-catalogd-catalogd-controller-manager.yml
@@ -19,7 +19,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
-        openshift.io/required-scc: restricted-v2
+        openshift.io/required-scc: privileged
       labels:
         control-plane: catalogd-controller-manager
     spec:
@@ -100,6 +100,9 @@ spec:
               name: cache
             - mountPath: /var/certs
               name: catalogserver-certs
+            - mountPath: /etc/containers
+              name: etc-containers
+              readOnly: true
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -113,4 +116,8 @@ spec:
           secret:
             optional: false
             secretName: catalogserver-cert
+        - hostPath:
+            path: /etc/containers
+            type: Directory
+          name: etc-containers
       priorityClassName: system-cluster-critical


### PR DESCRIPTION
In order for catalogd to support disconnected clusters in OCP, it needs access to the /etc/containers directory on the node. This PR adds a hostPath volume mount to give it that access. It also changes the security configuration of the namespace and pod to allow privileged access (which is required for hostPath volume mounts).