### PR TITLE
OPRUN-3558: Add hostPath mount for /var/lib/kubelet

### DIFF
--- a/openshift/generate-manifests.sh
+++ b/openshift/generate-manifests.sh
@@ -52,7 +52,7 @@ mkdir -p "${TMP_ROOT}/openshift"
 cp -a "${REPO_ROOT}/openshift/kustomize" "${TMP_ROOT}/openshift/kustomize"
 
 # Override OPENSHIFT-NAMESPACE to ${NAMESPACE}
-find "${TMP_ROOT}" -name "*.yaml" -exec sed -i "s/OPENSHIFT-NAMESPACE/${NAMESPACE}/g" {} \;
+find "${TMP_ROOT}" -name "*.yaml" -exec sed -i.tmp "s/OPENSHIFT-NAMESPACE/${NAMESPACE}/g" {} \;
 
 # Create a temp dir for manifests
 TMP_MANIFEST_DIR="${TMP_ROOT}/manifests"

--- a/openshift/kustomize/overlays/openshift/kustomization.yaml
+++ b/openshift/kustomize/overlays/openshift/kustomization.yaml
@@ -30,3 +30,7 @@ patches:
     kind: Deployment
     name: controller-manager
   path: patches/manager_deployment_mount_etc_containers.yaml
+- target:
+      kind: Deployment
+      name: controller-manager
+  path: patches/manager_deployment_mount_auth_host.yaml

--- a/openshift/kustomize/overlays/openshift/patches/manager_deployment_mount_auth_host.yaml
+++ b/openshift/kustomize/overlays/openshift/patches/manager_deployment_mount_auth_host.yaml
@@ -1,0 +1,6 @@
+- op: add
+  path: /spec/template/spec/volumes/-
+  value: {"name":"global-auth-file", "hostPath":{"path":"/var/lib/kubelet/config.json", "type": "File"}}
+- op: add
+  path: /spec/template/spec/containers/1/volumeMounts/-
+  value: {"name":"global-auth-file", "readOnly": true, "mountPath":"/etc/catalogd/auth.json"}

--- a/openshift/manifests/11-deployment-openshift-catalogd-catalogd-controller-manager.yml
+++ b/openshift/manifests/11-deployment-openshift-catalogd-catalogd-controller-manager.yml
@@ -103,6 +103,9 @@ spec:
             - mountPath: /etc/containers
               name: etc-containers
               readOnly: true
+            - mountPath: /etc/catalogd/auth.json
+              name: global-auth-file
+              readOnly: true
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -120,4 +123,8 @@ spec:
             path: /etc/containers
             type: Directory
           name: etc-containers
+        - hostPath:
+            path: /var/lib/kubelet/config.json
+            type: File
+          name: global-auth-file
       priorityClassName: system-cluster-critical


### PR DESCRIPTION
MCO makes the global pull secrets available in `/var/lib/kubelet`. Catalogd will look for these secrets in `/etc/catalogd` folder, ref [catalogd:416](https://github.com/operator-framework/catalogd/pull/416).

This PR hostPath mounts the `/var/lib/kublet` directory from the host to the `/etc/catalogd` directory in the container's filesystem.

RFC: [OLMv1 Private registry support](https://docs.google.com/document/d/1BXD6kj5zXHcGiqvJOikU2xs8kV26TPnzEKp6n7TKD4M/edit?usp=sharing)