### PR TITLE
NO-ISSUE: UPSTREAM: <carry>: set priorities on default catalogs

### DIFF
--- a/openshift/kustomize/overlays/openshift/catalogs/openshift-certified-operators.yaml
+++ b/openshift/kustomize/overlays/openshift/catalogs/openshift-certified-operators.yaml
@@ -3,6 +3,7 @@ kind: ClusterCatalog
 metadata:
   name: openshift-certified-operators
 spec:
+  priority: -200
   source:
     type: Image
     image:

--- a/openshift/kustomize/overlays/openshift/catalogs/openshift-community-operators.yaml
+++ b/openshift/kustomize/overlays/openshift/catalogs/openshift-community-operators.yaml
@@ -3,6 +3,7 @@ kind: ClusterCatalog
 metadata:
   name: openshift-community-operators
 spec:
+  priority: -400
   source:
     type: Image
     image:

--- a/openshift/kustomize/overlays/openshift/catalogs/openshift-redhat-marketplace.yaml
+++ b/openshift/kustomize/overlays/openshift/catalogs/openshift-redhat-marketplace.yaml
@@ -3,6 +3,7 @@ kind: ClusterCatalog
 metadata:
   name: openshift-redhat-marketplace
 spec:
+  priority: -300
   source:
     type: Image
     image:

--- a/openshift/kustomize/overlays/openshift/catalogs/openshift-redhat-operators.yaml
+++ b/openshift/kustomize/overlays/openshift/catalogs/openshift-redhat-operators.yaml
@@ -3,6 +3,7 @@ kind: ClusterCatalog
 metadata:
   name: openshift-redhat-operators
 spec:
+  priority: -100
   source:
     type: Image
     image:

--- a/openshift/manifests/14-clustercatalog-openshift-certified-operators.yml
+++ b/openshift/manifests/14-clustercatalog-openshift-certified-operators.yml
@@ -4,6 +4,7 @@ kind: ClusterCatalog
 metadata:
   name: openshift-certified-operators
 spec:
+  priority: -200
   source:
     image:
       pollInterval: 10m0s

--- a/openshift/manifests/15-clustercatalog-openshift-community-operators.yml
+++ b/openshift/manifests/15-clustercatalog-openshift-community-operators.yml
@@ -4,6 +4,7 @@ kind: ClusterCatalog
 metadata:
   name: openshift-community-operators
 spec:
+  priority: -400
   source:
     image:
       pollInterval: 10m0s

--- a/openshift/manifests/16-clustercatalog-openshift-redhat-marketplace.yml
+++ b/openshift/manifests/16-clustercatalog-openshift-redhat-marketplace.yml
@@ -4,6 +4,7 @@ kind: ClusterCatalog
 metadata:
   name: openshift-redhat-marketplace
 spec:
+  priority: -300
   source:
     image:
       pollInterval: 10m0s

--- a/openshift/manifests/17-clustercatalog-openshift-redhat-operators.yml
+++ b/openshift/manifests/17-clustercatalog-openshift-redhat-operators.yml
@@ -4,6 +4,7 @@ kind: ClusterCatalog
 metadata:
   name: openshift-redhat-operators
 spec:
+  priority: -100
   source:
     image:
       pollInterval: 10m0s


### PR DESCRIPTION
In OLMv0, we set priorities on OCP's default catalogs, with the following priorities:
1. redhat-operators: `-100`
1. certified-operators: `-200`
1. redhat-marketplace: `-300`
1. community-operators: `-400`

When OLMv1 is disambiguating for bundle selection between two catalogs that have the same package name, these priorities will be used to break ties.

We choose negative numbers here so that custom catalogs installed by users have a higher priority by default than all of OCP's default catalogs.
