### PR TITLE
OPRUN-3605: Update nodeSelector and tolerations on catalogd deployment

### DIFF
--- a/openshift/kustomize/overlays/openshift/olmv1-ns/kustomization.yaml
+++ b/openshift/kustomize/overlays/openshift/olmv1-ns/kustomization.yaml
@@ -34,3 +34,7 @@ patches:
     kind: Deployment
     name: controller-manager
   path: patches/manager_deployment_log_verbosity.yaml
+- target:
+    kind: Deployment
+    name: controller-manager
+  path: patches/manager_deployment_node_selection.yaml

--- a/openshift/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_node_selection.yaml
+++ b/openshift/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_node_selection.yaml
@@ -1,0 +1,25 @@
+- op: add
+  path: /spec/template/spec/nodeSelector
+  value: { "kubernetes.io/os": "linux", "node-role.kubernetes.io/master": "" }
+- op: add
+  path: /spec/template/spec/tolerations
+  value:
+    [
+      {
+        "effect": "NoSchedule",
+        "key": "node-role.kubernetes.io/master",
+        "operator": "Exists",
+      },
+      {
+        "effect": "NoExecute",
+        "key": "node.kubernetes.io/unreachable",
+        "operator": "Exists",
+        "tolerationSeconds": 120,
+      },
+      {
+        "effect": "NoExecute",
+        "key": "node.kubernetes.io/not-ready",
+        "operator": "Exists",
+        "tolerationSeconds": 120,
+      },
+    ]

--- a/openshift/manifests/13-deployment-openshift-catalogd-catalogd-controller-manager.yml
+++ b/openshift/manifests/13-deployment-openshift-catalogd-catalogd-controller-manager.yml
@@ -106,12 +106,27 @@ spec:
             - mountPath: /etc/containers
               name: etc-containers
               readOnly: true
+      nodeSelector:
+        kubernetes.io/os: linux
+        node-role.kubernetes.io/master: ""
       securityContext:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: catalogd-controller-manager
       terminationGracePeriodSeconds: 10
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 120
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 120
       volumes:
         - emptyDir: {}
           name: cache


### PR DESCRIPTION
Updates the nodeSelector and toleration on the catalogd deployment to allow it to be scheduled on the master node.