### PR TITLE
OPRUN-3605: UPSTREAM: <carry>: namespace: use privileged PSA for audit and warn levels

### DIFF
--- a/openshift/kustomize/overlays/openshift/olmv1-ns/patches/manager_namespace_privileged.yaml
+++ b/openshift/kustomize/overlays/openshift/olmv1-ns/patches/manager_namespace_privileged.yaml
@@ -3,4 +3,9 @@ kind: Namespace
 metadata:
   name: system
   labels:
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/warn-version: latest
     pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest

--- a/openshift/manifests/00-namespace-openshift-catalogd.yml
+++ b/openshift/manifests/00-namespace-openshift-catalogd.yml
@@ -3,8 +3,12 @@ kind: Namespace
 metadata:
   labels:
     app.kubernetes.io/part-of: olm
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit-version: latest
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/warn-version: latest
   name: openshift-catalogd
   annotations:
     workload.openshift.io/allowed: management


### PR DESCRIPTION
It seems we need to set audit and warn levels to privileged to avoid tripping PSA PodSecurityViolation alerts.