### PR TITLE
ose-olm-catalogd-container: incomplete fix for rapid reset (CVE-2023-39325/CVE-2023-44487) [openshift-4.20] 

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -166,7 +166,6 @@ func main() {
 		// - HTTP/2 Rapid Reset (GHSA-4374-p667-p6c8)
 		// While CVE fixes exist, they remain insufficient; disabling HTTP/2 helps reduce risks.
 		// For details, see: https://github.com/kubernetes/kubernetes/issues/121197
-		setupLog.Info("disabling http/2")
 		config.NextProtos = []string{"http/1.1"}
 	}
 


### PR DESCRIPTION
Cheery pick from https://github.com/operator-framework/catalogd

- https://github.com/operator-framework/catalogd/pull/484
- https://github.com/operator-framework/catalogd/pull/492