### PR TITLE
OCPBUGS-48640: Add service-ca into catalogd trusted certs

### DIFF
--- a/openshift/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_certs.yaml
+++ b/openshift/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_certs.yaml
@@ -5,11 +5,17 @@
   path: /spec/template/spec/volumes/-
   value: {"name":"trusted-ca-bundle", "configMap":{"optional":false,"name":"trusted-ca-bundle"}}
 - op: add
+  path: /spec/template/spec/volumes/-
+  value: {"name":"service-ca", "configMap":{"optional":false,"name":"openshift-service-ca.crt"}}
+- op: add
   path: /spec/template/spec/containers/0/volumeMounts/-
   value: {"name":"catalogserver-certs", "mountPath":"/var/certs"}
 - op: add
   path: /spec/template/spec/containers/0/volumeMounts/-
-  value: {"name":"trusted-ca-bundle", "mountPath":"/var/trusted-cas"}
+  value: {"name":"trusted-ca-bundle", "mountPath":"/var/trusted-cas/ca-bundle.crt", "subPath":"ca-bundle.crt"}
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value: {"name":"service-ca", "mountPath":"/var/trusted-cas/service-ca.crt", "subPath":"service-ca.crt"}
 - op: add
   path: /spec/template/spec/containers/0/args/-
   value: "--tls-cert=/var/certs/tls.crt"

--- a/openshift/manifests/14-deployment-openshift-catalogd-catalogd-controller-manager.yml
+++ b/openshift/manifests/14-deployment-openshift-catalogd-catalogd-controller-manager.yml
@@ -81,8 +81,12 @@ spec:
               name: cache
             - mountPath: /var/certs
               name: catalogserver-certs
-            - mountPath: /var/trusted-cas
+            - mountPath: /var/trusted-cas/ca-bundle.crt
               name: trusted-ca-bundle
+              subPath: ca-bundle.crt
+            - mountPath: /var/trusted-cas/service-ca.crt
+              name: service-ca
+              subPath: service-ca.crt
             - mountPath: /etc/containers
               name: etc-containers
               readOnly: true
@@ -118,6 +122,10 @@ spec:
             name: catalogd-trusted-ca-bundle
             optional: false
           name: trusted-ca-bundle
+        - configMap:
+            name: openshift-service-ca.crt
+            optional: false
+          name: service-ca
         - hostPath:
             path: /etc/containers
             type: Directory


### PR DESCRIPTION
UPSTREAM: <carry>: Add service-ca into catalogd trusted certs

This is necessary to get the operator-controller e2e to work