### PR TITLE
OCPBUGS-48795: Add /etc/docker to the catalogd deployment

### DIFF
--- a/openshift/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_mount_etc_containers.yaml
+++ b/openshift/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_mount_etc_containers.yaml
@@ -4,3 +4,9 @@
 - op: add
   path: /spec/template/spec/containers/0/volumeMounts/-
   value: {"name":"etc-containers", "readOnly": true, "mountPath":"/etc/containers"}
+- op: add
+  path: /spec/template/spec/volumes/-
+  value: {"name":"etc-docker", "hostPath":{"path":"/etc/docker", "type": "Directory"}}
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value: {"name":"etc-docker", "readOnly": true, "mountPath":"/etc/docker"}

--- a/openshift/manifests/14-deployment-openshift-catalogd-catalogd-controller-manager.yml
+++ b/openshift/manifests/14-deployment-openshift-catalogd-catalogd-controller-manager.yml
@@ -90,6 +90,9 @@ spec:
             - mountPath: /etc/containers
               name: etc-containers
               readOnly: true
+            - mountPath: /etc/docker
+              name: etc-docker
+              readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
         node-role.kubernetes.io/master: ""
@@ -133,4 +136,8 @@ spec:
             path: /etc/containers
             type: Directory
           name: etc-containers
+        - hostPath:
+            path: /etc/docker
+            type: Directory
+          name: etc-docker
       priorityClassName: system-cluster-critical


### PR DESCRIPTION
This allows for use of the any image.config.openshift.io trusted CAs