### PR TITLE
OCPBUGS-49622: Fix leaderelection settings

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -42,6 +42,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/textlogger"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	crcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
@@ -203,8 +204,14 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "catalogd-operator-lock",
-		WebhookServer:          webhookServer,
-		Cache:                  cacheOptions,
+		// Recommended Leader Election values
+		// https://github.com/openshift/enhancements/blob/61581dcd985130357d6e4b0e72b87ee35394bf6e/CONVENTIONS.md#handling-kube-apiserver-disruption
+		LeaseDuration: ptr.To(137 * time.Second),
+		RenewDeadline: ptr.To(107 * time.Second),
+		RetryPeriod:   ptr.To(26 * time.Second),
+
+		WebhookServer: webhookServer,
+		Cache:         cacheOptions,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to create manager")


### PR DESCRIPTION
This is a manual backport of https://github.com/openshift/operator-framework-operator-controller/pull/249
to fix leaderelection settings
