### PR TITLE
OCPBUGS-49759: Revert "[release-4.18] OCPBUGS-49715: CA cert and catalog cache bug fixes"

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -96,7 +96,7 @@ func main() {
 		certFile             string
 		keyFile              string
 		webhookPort          int
-		pullCasDir           string
+		caCertDir            string
 		globalPullSecret     string
 	)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -114,7 +114,7 @@ func main() {
 	flag.StringVar(&certFile, "tls-cert", "", "The certificate file used for serving catalog contents over HTTPS. Requires tls-key.")
 	flag.StringVar(&keyFile, "tls-key", "", "The key file used for serving catalog contents over HTTPS. Requires tls-cert.")
 	flag.IntVar(&webhookPort, "webhook-server-port", 9443, "The port that the mutating webhook server serves at.")
-	flag.StringVar(&pullCasDir, "pull-cas-dir", "", "The directory of TLS certificate authoritiess to use for verifying HTTPS connections to image registries.")
+	flag.StringVar(&caCertDir, "ca-certs-dir", "", "The directory of CA certificate to use for verifying HTTPS connections to image registries.")
 	flag.StringVar(&globalPullSecret, "global-pull-secret", "", "The <namespace>/<name> of the global pull secret that is going to be used to pull bundle images.")
 
 	klog.InitFlags(flag.CommandLine)
@@ -243,8 +243,8 @@ func main() {
 		BaseCachePath: unpackCacheBasePath,
 		SourceContextFunc: func(logger logr.Logger) (*types.SystemContext, error) {
 			srcContext := &types.SystemContext{
-				DockerCertPath: pullCasDir,
-				OCICertPath:    pullCasDir,
+				DockerCertPath: caCertDir,
+				OCICertPath:    caCertDir,
 			}
 			if _, err := os.Stat(authFilePath); err == nil && globalPullSecretKey != nil {
 				logger.Info("using available authentication information for pulling image")

--- a/config/components/ca/patches/manager_deployment_cacerts.yaml
+++ b/config/components/ca/patches/manager_deployment_cacerts.yaml
@@ -6,4 +6,4 @@
   value: {"name":"olmv1-certificate", "readOnly": true, "mountPath":"/var/ca-certs/"}
 - op: add
   path: /spec/template/spec/containers/1/args/-
-  value: "--pull-cas-dir=/var/ca-certs"
+  value: "--ca-certs-dir=/var/ca-certs"

--- a/openshift/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_certs.yaml
+++ b/openshift/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_certs.yaml
@@ -3,13 +3,19 @@
   value: {"name":"catalogserver-certs", "secret":{"optional":false,"secretName":"catalogserver-cert"}}
 - op: add
   path: /spec/template/spec/volumes/-
-  value: {"name":"ca-certs", "projected": {"sources":[{"configMap":{"optional":false,"name":"trusted-ca-bundle", "items":[{"key":"ca-bundle.crt","path":"ca-bundle.crt"}]}},{"configMap":{"optional":false,"name":"openshift-service-ca.crt", "items":[{"key":"service-ca.crt","path":"service-ca.crt"}]}}]}}
+  value: {"name":"trusted-ca-bundle", "configMap":{"optional":false,"name":"trusted-ca-bundle", "items":[{"key":"ca-bundle.crt","path":"ca-bundle.crt"}]}}
+- op: add
+  path: /spec/template/spec/volumes/-
+  value: {"name":"service-ca", "configMap":{"optional":false,"name":"openshift-service-ca.crt", "items":[{"key":"service-ca.crt","path":"service-ca.crt"}]}}
 - op: add
   path: /spec/template/spec/containers/1/volumeMounts/-
   value: {"name":"catalogserver-certs", "mountPath":"/var/certs"}
 - op: add
   path: /spec/template/spec/containers/1/volumeMounts/-
-  value: {"name":"ca-certs", "mountPath":"/var/ca-certs", "readOnly": true}
+  value: {"name":"trusted-ca-bundle", "mountPath":"/var/trusted-cas/ca-bundle.crt", "subPath":"ca-bundle.crt"}
+- op: add
+  path: /spec/template/spec/containers/1/volumeMounts/-
+  value: {"name":"service-ca", "mountPath":"/var/trusted-cas/service-ca.crt", "subPath":"service-ca.crt"}
 - op: add
   path: /spec/template/spec/containers/1/args/-
   value: "--tls-cert=/var/certs/tls.crt"
@@ -17,5 +23,5 @@
   path: /spec/template/spec/containers/1/args/-
   value: "--tls-key=/var/certs/tls.key"
 - op: add
-  path: /spec/template/spec/containers/1/env
-  value: [{"name":"SSL_CERT_DIR", "value":"/var/ca-certs"}]
+  path: /spec/template/spec/containers/1/args/-
+  value: "--ca-certs-dir=/var/trusted-cas"

--- a/openshift/manifests/14-deployment-openshift-catalogd-catalogd-controller-manager.yml
+++ b/openshift/manifests/14-deployment-openshift-catalogd-catalogd-controller-manager.yml
@@ -68,13 +68,11 @@ spec:
             - --external-address=catalogd-service.openshift-catalogd.svc
             - --tls-cert=/var/certs/tls.crt
             - --tls-key=/var/certs/tls.key
+            - --ca-certs-dir=/var/trusted-cas
             - --v=${LOG_VERBOSITY}
             - --global-pull-secret=openshift-config/pull-secret
           command:
             - ./manager
-          env:
-            - name: SSL_CERT_DIR
-              value: /var/ca-certs
           image: ${CATALOGD_IMAGE}
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -105,9 +103,12 @@ spec:
               name: cache
             - mountPath: /var/certs
               name: catalogserver-certs
-            - mountPath: /var/ca-certs
-              name: ca-certs
-              readOnly: true
+            - mountPath: /var/trusted-cas/ca-bundle.crt
+              name: trusted-ca-bundle
+              subPath: ca-bundle.crt
+            - mountPath: /var/trusted-cas/service-ca.crt
+              name: service-ca
+              subPath: service-ca.crt
             - mountPath: /etc/containers
               name: etc-containers
               readOnly: true
@@ -139,21 +140,20 @@ spec:
           secret:
             optional: false
             secretName: catalogserver-cert
-        - name: ca-certs
-          projected:
-            sources:
-              - configMap:
-                  items:
-                    - key: ca-bundle.crt
-                      path: ca-bundle.crt
-                  name: catalogd-trusted-ca-bundle
-                  optional: false
-              - configMap:
-                  items:
-                    - key: service-ca.crt
-                      path: service-ca.crt
-                  name: openshift-service-ca.crt
-                  optional: false
+        - configMap:
+            items:
+              - key: ca-bundle.crt
+                path: ca-bundle.crt
+            name: catalogd-trusted-ca-bundle
+            optional: false
+          name: trusted-ca-bundle
+        - configMap:
+            items:
+              - key: service-ca.crt
+                path: service-ca.crt
+            name: openshift-service-ca.crt
+            optional: false
+          name: service-ca
         - hostPath:
             path: /etc/containers
             type: Directory


### PR DESCRIPTION
Reverts openshift/operator-framework-catalogd#128 due to failing singlenode jobs noted in

[TRT-1985](https://issues.redhat.com/browse/TRT-1985)

Testing with
/payload-job periodic-ci-openshift-release-master-ci-4.19-e2e-aws-upgrade-ovn-single-node