### PR TITLE
[release-4.18] OCPBUGS-51140: Cache invalidate backport

### DIFF
--- a/internal/source/containers_image.go
+++ b/internal/source/containers_image.go
@@ -20,6 +20,7 @@ import (
 	"github.com/containers/image/v5/oci/layout"
 	"github.com/containers/image/v5/pkg/blobinfocache/none"
 	"github.com/containers/image/v5/pkg/compression"
+	"github.com/containers/image/v5/pkg/sysregistriesv2"
 	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/types"
 	"github.com/go-logr/logr"
@@ -48,6 +49,9 @@ func (i *ContainersImageRegistry) Unpack(ctx context.Context, catalog *catalogdv
 	if catalog.Spec.Source.Image == nil {
 		return nil, reconcile.TerminalError(fmt.Errorf("error parsing catalog, catalog %s has a nil image source", catalog.Name))
 	}
+
+	// Reload registries cache in case of configuration update
+	sysregistriesv2.InvalidateCache()
 
 	srcCtx, err := i.SourceContextFunc(l)
 	if err != nil {


### PR DESCRIPTION
Manual backport of [this commit](https://github.com/openshift/operator-framework-operator-controller/commit/f26bf236f3012a50efe89073a0d3dae26e75af86) in the downstream operator-controller monorepo.