### PR TITLE
[release-4.18] OCPBUGS-52173: unset PAXRecords and Xattrs in image layers when applying to disk

### DIFF
--- a/internal/source/containers_image.go
+++ b/internal/source/containers_image.go
@@ -337,6 +337,8 @@ func applyLayerFilter(srcPath string) archive.Filter {
 		h.Uid = os.Getuid()
 		h.Gid = os.Getgid()
 		h.Mode |= 0700
+		h.PAXRecords = nil
+		h.Xattrs = nil //nolint:staticcheck
 
 		cleanName := path.Clean(strings.TrimPrefix(h.Name, "/"))
 		relPath, err := filepath.Rel(cleanSrcPath, cleanName)


### PR DESCRIPTION
Manual cherry pick of https://github.com/openshift/operator-framework-operator-controller/pull/280

Note that the original bug (https://issues.redhat.com/browse/OCPBUGS-52161) was about bundle images, which are purely in the domain of operator-controller (not catalogd). However, 4.19 has an image unpacking library that is shared between operator-controller and catalogd, so when we fixed this issue for bundle images in 4.19, we _also_ fixed it for catalog images.

Since we are backporting the 4.19 fix to 4.18, it is necessary to change catalogd's 4.18 image unpacking implementation to ensure that the 4.19 fix is actually fully applied in 4.18.