### PR TITLE
OCPBUGS-51241: Bump Go JOSE to v4.0.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.6.1 // indirect
 	github.com/go-git/go-git/v5 v5.13.1 // indirect
-	github.com/go-jose/go-jose/v4 v4.0.2 // indirect
+	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
 	github.com/go-openapi/analysis v0.23.0 // indirect
 	github.com/go-openapi/errors v0.22.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/go-git/go-billy/v5 v5.6.1 h1:u+dcrgaguSSkbjzHwelEjc0Yj300NUevrrPphk/S
 github.com/go-git/go-billy/v5 v5.6.1/go.mod h1:0AsLr1z2+Uksi4NlElmMblP5rPcDZNRCD8ujZCRR2BE=
 github.com/go-git/go-git/v5 v5.13.1 h1:DAQ9APonnlvSWpvolXWIuV6Q6zXy2wHbN4cVlNR5Q+M=
 github.com/go-git/go-git/v5 v5.13.1/go.mod h1:qryJB4cSBoq3FRoBRf5A77joojuBcmPJ0qu3XXXVixc=
-github.com/go-jose/go-jose/v4 v4.0.2 h1:R3l3kkBds16bO7ZFAEEcofK0MkrAJt3jlJznWZG0nvk=
-github.com/go-jose/go-jose/v4 v4.0.2/go.mod h1:WVf9LFMHh/QVrmqrOfqun0C45tMe3RoiKJMPvgWwLfY=
+github.com/go-jose/go-jose/v4 v4.0.5 h1:M6T8+mKZl/+fNNuFHvGIzDz7BTLQPIounk/b9dw3AaE=
+github.com/go-jose/go-jose/v4 v4.0.5/go.mod h1:s3P1lRrkT8igV8D9OjyL4WRyHvjB6a4JSllnOrmmBOA=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=

--- a/vendor/github.com/go-jose/go-jose/v4/CHANGELOG.md
+++ b/vendor/github.com/go-jose/go-jose/v4/CHANGELOG.md
@@ -1,3 +1,27 @@
+# v4.0.4
+
+## Fixed
+
+ - Reverted "Allow unmarshalling JSONWebKeySets with unsupported key types" as a
+   breaking change. See #136 / #137.
+
+# v4.0.3
+
+## Changed
+
+ - Allow unmarshalling JSONWebKeySets with unsupported key types (#130)
+ - Document that OpaqueKeyEncrypter can't be implemented (for now) (#129)
+ - Dependency updates
+
+# v4.0.2
+
+## Changed
+
+ - Improved documentation of Verify() to note that JSONWebKeySet is a supported
+   argument type (#104)
+ - Defined exported error values for missing x5c header and unsupported elliptic
+   curves error cases (#117)
+
 # v4.0.1
 
 ## Fixed

--- a/vendor/github.com/go-jose/go-jose/v4/CONTRIBUTING.md
+++ b/vendor/github.com/go-jose/go-jose/v4/CONTRIBUTING.md
@@ -7,9 +7,3 @@ When submitting code, please make every effort to follow existing conventions
 and style in order to keep the code as readable as possible. Please also make
 sure all tests pass by running `go test`, and format your code with `go fmt`.
 We also recommend using `golint` and `errcheck`.
-
-Before your code can be accepted into the project you must also sign the
-Individual Contributor License Agreement.  We use [cla-assistant.io][1] and you
-will be prompted to sign once a pull request is opened.
-
-[1]: https://cla-assistant.io/

--- a/vendor/github.com/go-jose/go-jose/v4/README.md
+++ b/vendor/github.com/go-jose/go-jose/v4/README.md
@@ -9,14 +9,6 @@ Package jose aims to provide an implementation of the Javascript Object Signing
 and Encryption set of standards. This includes support for JSON Web Encryption,
 JSON Web Signature, and JSON Web Token standards.
 
-**Disclaimer**: This library contains encryption software that is subject to
-the U.S. Export Administration Regulations. You may not export, re-export,
-transfer or download this code or any part of it in violation of any United
-States law, directive or regulation. In particular this software may not be
-exported or re-exported in any form or on any media to Iran, North Sudan,
-Syria, Cuba, or North Korea, or to denied persons or entities mentioned on any
-US maintained blocked list.
-
 ## Overview
 
 The implementation follows the
@@ -109,6 +101,6 @@ allows attaching a key id.
 
 Examples can be found in the Godoc
 reference for this package. The
-[`jose-util`](https://github.com/go-jose/go-jose/tree/v4/jose-util)
+[`jose-util`](https://github.com/go-jose/go-jose/tree/main/jose-util)
 subdirectory also contains a small command-line utility which might be useful
 as an example as well.

--- a/vendor/github.com/go-jose/go-jose/v4/crypter.go
+++ b/vendor/github.com/go-jose/go-jose/v4/crypter.go
@@ -459,7 +459,10 @@ func (obj JSONWebEncryption) Decrypt(decryptionKey interface{}) ([]byte, error) 
 		return nil, fmt.Errorf("go-jose/go-jose: unsupported crit header")
 	}
 
-	key := tryJWKS(decryptionKey, obj.Header)
+	key, err := tryJWKS(decryptionKey, obj.Header)
+	if err != nil {
+		return nil, err
+	}
 	decrypter, err := newDecrypter(key)
 	if err != nil {
 		return nil, err
@@ -529,7 +532,10 @@ func (obj JSONWebEncryption) DecryptMulti(decryptionKey interface{}) (int, Heade
 		return -1, Header{}, nil, fmt.Errorf("go-jose/go-jose: unsupported crit header")
 	}
 
-	key := tryJWKS(decryptionKey, obj.Header)
+	key, err := tryJWKS(decryptionKey, obj.Header)
+	if err != nil {
+		return -1, Header{}, nil, err
+	}
 	decrypter, err := newDecrypter(key)
 	if err != nil {
 		return -1, Header{}, nil, err

--- a/vendor/github.com/go-jose/go-jose/v4/jwe.go
+++ b/vendor/github.com/go-jose/go-jose/v4/jwe.go
@@ -288,10 +288,11 @@ func ParseEncryptedCompact(
 	keyAlgorithms []KeyAlgorithm,
 	contentEncryption []ContentEncryption,
 ) (*JSONWebEncryption, error) {
-	parts := strings.Split(input, ".")
-	if len(parts) != 5 {
+	// Five parts is four separators
+	if strings.Count(input, ".") != 4 {
 		return nil, fmt.Errorf("go-jose/go-jose: compact JWE format must have five parts")
 	}
+	parts := strings.SplitN(input, ".", 5)
 
 	rawProtected, err := base64.RawURLEncoding.DecodeString(parts[0])
 	if err != nil {

--- a/vendor/github.com/go-jose/go-jose/v4/jwk.go
+++ b/vendor/github.com/go-jose/go-jose/v4/jwk.go
@@ -239,10 +239,10 @@ func (k *JSONWebKey) UnmarshalJSON(data []byte) (err error) {
 				keyPub = key
 			}
 		} else {
-			err = fmt.Errorf("go-jose/go-jose: unknown curve %s'", raw.Crv)
+			return fmt.Errorf("go-jose/go-jose: unknown curve %s'", raw.Crv)
 		}
 	default:
-		err = fmt.Errorf("go-jose/go-jose: unknown json web key type '%s'", raw.Kty)
+		return fmt.Errorf("go-jose/go-jose: unknown json web key type '%s'", raw.Kty)
 	}
 
 	if err != nil {
@@ -779,7 +779,13 @@ func (key rawJSONWebKey) symmetricKey() ([]byte, error) {
 	return key.K.bytes(), nil
 }
 
-func tryJWKS(key interface{}, headers ...Header) interface{} {
+var (
+	// ErrJWKSKidNotFound is returned when a JWKS does not contain a JWK with a
+	// key ID which matches one in the provided tokens headers.
+	ErrJWKSKidNotFound = errors.New("go-jose/go-jose: JWK with matching kid not found in JWK Set")
+)
+
+func tryJWKS(key interface{}, headers ...Header) (interface{}, error) {
 	var jwks JSONWebKeySet
 
 	switch jwksType := key.(type) {
@@ -788,9 +794,11 @@ func tryJWKS(key interface{}, headers ...Header) interface{} {
 	case JSONWebKeySet:
 		jwks = jwksType
 	default:
-		return key
+		// If the specified key is not a JWKS, return as is.
+		return key, nil
 	}
 
+	// Determine the KID to search for from the headers.
 	var kid string
 	for _, header := range headers {
 		if header.KeyID != "" {
@@ -799,14 +807,17 @@ func tryJWKS(key interface{}, headers ...Header) interface{} {
 		}
 	}
 
+	// If no KID is specified in the headers, reject.
 	if kid == "" {
-		return key
+		return nil, ErrJWKSKidNotFound
 	}
 
+	// Find the JWK with the matching KID. If no JWK with the specified KID is
+	// found, reject.
 	keys := jwks.Key(kid)
 	if len(keys) == 0 {
-		return key
+		return nil, ErrJWKSKidNotFound
 	}
 
-	return keys[0].Key
+	return keys[0].Key, nil
 }

--- a/vendor/github.com/go-jose/go-jose/v4/jws.go
+++ b/vendor/github.com/go-jose/go-jose/v4/jws.go
@@ -327,10 +327,11 @@ func parseSignedCompact(
 	payload []byte,
 	signatureAlgorithms []SignatureAlgorithm,
 ) (*JSONWebSignature, error) {
-	parts := strings.Split(input, ".")
-	if len(parts) != 3 {
+	// Three parts is two separators
+	if strings.Count(input, ".") != 2 {
 		return nil, fmt.Errorf("go-jose/go-jose: compact JWS format must have three parts")
 	}
+	parts := strings.SplitN(input, ".", 3)
 
 	if parts[1] != "" && payload != nil {
 		return nil, fmt.Errorf("go-jose/go-jose: payload is not detached")

--- a/vendor/github.com/go-jose/go-jose/v4/opaque.go
+++ b/vendor/github.com/go-jose/go-jose/v4/opaque.go
@@ -83,6 +83,9 @@ func (o *opaqueVerifier) verifyPayload(payload []byte, signature []byte, alg Sig
 }
 
 // OpaqueKeyEncrypter is an interface that supports encrypting keys with an opaque key.
+//
+// Note: this cannot currently be implemented outside this package because of its
+// unexported method.
 type OpaqueKeyEncrypter interface {
 	// KeyID returns the kid
 	KeyID() string

--- a/vendor/github.com/go-jose/go-jose/v4/signing.go
+++ b/vendor/github.com/go-jose/go-jose/v4/signing.go
@@ -390,7 +390,10 @@ func (obj JSONWebSignature) UnsafePayloadWithoutVerification() []byte {
 // The verificationKey argument must have one of the types allowed for the
 // verificationKey argument of JSONWebSignature.Verify().
 func (obj JSONWebSignature) DetachedVerify(payload []byte, verificationKey interface{}) error {
-	key := tryJWKS(verificationKey, obj.headers()...)
+	key, err := tryJWKS(verificationKey, obj.headers()...)
+	if err != nil {
+		return err
+	}
 	verifier, err := newVerifier(key)
 	if err != nil {
 		return err
@@ -455,7 +458,10 @@ func (obj JSONWebSignature) VerifyMulti(verificationKey interface{}) (int, Signa
 // The verificationKey argument must have one of the types allowed for the
 // verificationKey argument of JSONWebSignature.Verify().
 func (obj JSONWebSignature) DetachedVerifyMulti(payload []byte, verificationKey interface{}) (int, Signature, error) {
-	key := tryJWKS(verificationKey, obj.headers()...)
+	key, err := tryJWKS(verificationKey, obj.headers()...)
+	if err != nil {
+		return -1, Signature{}, err
+	}
 	verifier, err := newVerifier(key)
 	if err != nil {
 		return -1, Signature{}, err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -226,7 +226,7 @@ github.com/go-git/go-git/v5/internal/path_util
 github.com/go-git/go-git/v5/plumbing/format/config
 github.com/go-git/go-git/v5/plumbing/format/gitignore
 github.com/go-git/go-git/v5/utils/ioutil
-# github.com/go-jose/go-jose/v4 v4.0.2
+# github.com/go-jose/go-jose/v4 v4.0.5
 ## explicit; go 1.21
 github.com/go-jose/go-jose/v4
 github.com/go-jose/go-jose/v4/cipher


### PR DESCRIPTION
[CVE-2025-27144](https://bugzilla.redhat.com/show_bug.cgi?id=2347423)