### PR TITLE
OCPBUGS-89330: Fix cache path to avoid /var/cache/dnf conflict

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -108,7 +108,7 @@ func main() {
 	flag.StringVar(&systemNamespace, "system-namespace", "", "The namespace catalogd uses for internal state, configuration, and workloads")
 	flag.StringVar(&catalogServerAddr, "catalogs-server-addr", ":8443", "The address where the unpacked catalogs' content will be accessible")
 	flag.StringVar(&externalAddr, "external-address", "catalogd-service.olmv1-system.svc", "The external address at which the http(s) server is reachable.")
-	flag.StringVar(&cacheDir, "cache-dir", "/var/cache/", "The directory in the filesystem that catalogd will use for file based caching")
+	flag.StringVar(&cacheDir, "cache-dir", "/var/cache/catalogd", "The directory in the filesystem that catalogd will use for file based caching")
 	flag.BoolVar(&catalogdVersion, "version", false, "print the catalogd version and exit")
 	flag.DurationVar(&gcInterval, "gc-interval", 12*time.Hour, "interval in which garbage collection should be run against the catalog content cache")
 	flag.StringVar(&certFile, "tls-cert", "", "The certificate file used for serving catalog and metrics. Required to enable the metrics server. Requires tls-key.")


### PR DESCRIPTION
## Problem

On OpenShift 4.19.32, catalogd pods crash on startup with:
```
chmod /var/cache/dnf: operation not permitted
```

This happens because:
1. Default cache directory is `/var/cache/`
2. RHEL base image contains `/var/cache/dnf` owned by root
3. Pod runs as non-root (UID 1001)
4. `EnsureEmptyDirectory()` tries to chmod root-owned directories, which fails

## Solution

Change default cache directory from `/var/cache/` to `/var/cache/catalogd` to avoid conflicts with system directories.

## Testing

- Build and deploy with new default
- Verify pod starts successfully
- Verify catalog cache operations work correctly

Fixes: https://redhat.atlassian.net/browse/OCPBUGS-89330